### PR TITLE
SMRT-1287 Fixing runtime injection of endpoint var

### DIFF
--- a/config/integration.exs
+++ b/config/integration.exs
@@ -6,10 +6,6 @@ host =
     defined -> defined
   end
 
-System.put_env("HOST", host)
-
-endpoint = [{to_charlist(host), 9092}]
-
 config :logger,
   level: :info
 
@@ -27,7 +23,7 @@ config :valkyrie,
 
 config :yeet,
   topic: "dead-letters",
-  endpoint: endpoint
+  endpoint: [{to_charlist(host), 9092}]
 
 config :smart_city_registry,
   redis: [

--- a/lib/valkyrie/message_handler.ex
+++ b/lib/valkyrie/message_handler.ex
@@ -9,7 +9,6 @@ defmodule Valkyrie.MessageHandler do
   alias SmartCity.Data
   alias Valkyrie.Validators
 
-  @endpoints Application.get_env(:valkyrie, :elsa_brokers)
   @initial_delay Application.get_env(:valkyrie, :produce_timeout)
   @retries Application.get_env(:valkyrie, :produce_retries)
 
@@ -57,11 +56,13 @@ defmodule Valkyrie.MessageHandler do
       Valkyrie.TopicManager.is_topic_ready?(topic)
     after
       true ->
-        Elsa.Producer.produce_sync(@endpoints, topic, 0, key, message)
+        Elsa.Producer.produce_sync(endpoint(), topic, 0, key, message)
     else
       error -> error
     end
   end
+
+  defp endpoint(), do: Application.get_env(:valkyrie, :elsa_brokers)
 
   defp outgoing_topic_prefix(), do: Application.get_env(:valkyrie, :output_topic_prefix)
   defp outgoing_topic(dataset_id), do: "#{outgoing_topic_prefix()}-#{dataset_id}"


### PR DESCRIPTION
co-authored-by: jeffgrunewald <jeff@grunewalddesign.com>

We did the bad thing and baked this into the message_handler by using module attributes; fixing.